### PR TITLE
Fix Mantine color scheme typing

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [colorScheme, setColorScheme] = useState('dark');
+  const [colorScheme, setColorScheme] = useState<'light' | 'dark'>('dark');
 
   const toggleColorScheme = () => {
     setColorScheme(colorScheme === 'dark' ? 'light' : 'dark');
@@ -26,7 +26,7 @@ export default function RootLayout({
         </head>
         <body>
           <MantineProvider forceColorScheme={colorScheme}>
-            <Group position="right" p="md">
+            <Group justify="flex-end" p="md">
               <Switch
                 checked={colorScheme === 'dark'}
                 onChange={toggleColorScheme}


### PR DESCRIPTION
## Summary
- Narrow MantineProvider color scheme state to `'light' | 'dark'`
- Use `justify` prop for `Group` alignment

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689bbbb10f448328b9c6621c4b40508f