### PR TITLE
feat: improve mobile responsiveness

### DIFF
--- a/app/components/ui/Terminal.tsx
+++ b/app/components/ui/Terminal.tsx
@@ -4,7 +4,16 @@ import { Typewriter } from 'react-simple-typewriter'
 
 export function Terminal() {
   return (
-    <div style={{ backgroundColor: '#1a1b26', borderRadius: '8px', padding: '20px', color: '#a9b1d6', width: '600px' }}>
+    <div
+      style={{
+        backgroundColor: '#1a1b26',
+        borderRadius: '8px',
+        padding: '20px',
+        color: '#a9b1d6',
+        width: '100%',
+        maxWidth: '600px',
+      }}
+    >
       <div style={{ marginBottom: '10px' }}>
         <span style={{ color: '#bb9af7' }}>user@goonsite</span>
         <span style={{ color: '#7dcfff' }}>:</span>

--- a/app/components/ui/macbook-scroll.tsx
+++ b/app/components/ui/macbook-scroll.tsx
@@ -65,10 +65,35 @@ export const MacbookScroll = ({
   const textTransform = useTransform(scrollYProgress, [0, 0.3], [0, 100]);
   const textOpacity = useTransform(scrollYProgress, [0, 0.2], [1, 0]);
 
+  if (isMobile) {
+    return (
+      <div
+        ref={ref}
+        className="flex flex-col items-center justify-center w-full py-10"
+      >
+        {title && (
+          <h2 className="dark:text-white text-neutral-800 text-2xl font-bold mb-6 text-center">
+            {title}
+          </h2>
+        )}
+        {src && (
+          <Image
+            src={src}
+            alt="preview"
+            width={320}
+            height={240}
+            className="rounded-lg"
+          />
+        )}
+        {badge && <div className="mt-4">{badge}</div>}
+      </div>
+    );
+  }
+
   return (
     <div
       ref={ref}
-      className="min-h-[200vh]  flex flex-col items-center py-0 md:py-80 justify-start flex-shrink-0 [perspective:800px] transform md:scale-100  scale-[0.35] sm:scale-50"
+      className="min-h-[200vh] flex flex-col items-center py-0 md:py-80 justify-start flex-shrink-0 [perspective:800px] transform md:scale-100 scale-[0.35] sm:scale-50"
     >
       <motion.h2
         style={{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,7 @@ export default function RootLayout({
     <MyProvider>
       <html lang="en" className={GeistSans.className}>
         <head>
+          <meta name="viewport" content="width=device-width, initial-scale=1" />
           <ColorSchemeScript />
         </head>
         <body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
         <Terminal />
 
         <div style={{marginTop: '40px', display: 'flex', flexDirection: 'column', alignItems: 'center'}}>
-          <div style={{display: 'flex', gap: '20px'}}>
+          <div style={{display: 'flex', gap: '20px', flexWrap: 'wrap', justifyContent: 'center'}}>
             <Button component={Link} href="/goon-hub">Goon Hub</Button>
             <Button component={Link} href="/goon-sploit">Goon-sploit</Button>
           </div>


### PR DESCRIPTION
## Summary
- add viewport meta for proper mobile scaling
- make terminal and home navigation layout responsive
- provide mobile fallback for 3D Macbook scroll

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_689bc022fff8832882524c47bb60da99