### PR TITLE
fix: chess win prompt not appearing due to unstable onWin callback

### DIFF
--- a/app/message-board/games/Chess.tsx
+++ b/app/message-board/games/Chess.tsx
@@ -211,6 +211,8 @@ export default function Chess_Game({ onWin }: ChessProps) {
   const boardRef = useRef<HTMLDivElement>(null);
   const gameRef = useRef(game);
   gameRef.current = game;
+  const onWinRef = useRef(onWin);
+  onWinRef.current = onWin;
 
   // ─── Derived state ──────────────────────────────────────────────────────
 
@@ -246,7 +248,7 @@ export default function Chess_Game({ onWin }: ChessProps) {
     if (gameStatus === 'won' && !winCalled) {
       setWinCalled(true);
       setTaunt(randomTaunt('lost'));
-      const timer = setTimeout(() => onWin(), 800);
+      const timer = setTimeout(() => onWinRef.current(), 800);
       return () => clearTimeout(timer);
     }
     if (gameStatus === 'lost') {
@@ -255,7 +257,7 @@ export default function Chess_Game({ onWin }: ChessProps) {
     if (gameStatus === 'draw') {
       setTaunt('Stalemate... I\'ll take it.');
     }
-  }, [gameStatus, winCalled, onWin]);
+  }, [gameStatus, winCalled]);
 
   // ─── Make a move (with animation) ──────────────────────────────────────
 

--- a/app/message-board/games/Chess.tsx
+++ b/app/message-board/games/Chess.tsx
@@ -200,7 +200,7 @@ export default function Chess_Game({ onWin }: ChessProps) {
   const [lastMove, setLastMove] = useState<{ from: Square; to: Square } | null>(null);
   const [botThinking, setBotThinking] = useState(false);
   const [taunt, setTaunt] = useState('Beat me at chess and you can leave a message.');
-  const [winCalled, setWinCalled] = useState(false);
+  const winCalledRef = useRef(false);
   const [animatingMove, setAnimatingMove] = useState<{
     from: { row: number; col: number };
     to: { row: number; col: number };
@@ -245,8 +245,8 @@ export default function Chess_Game({ onWin }: ChessProps) {
   // ─── Win callback ───────────────────────────────────────────────────────
 
   useEffect(() => {
-    if (gameStatus === 'won' && !winCalled) {
-      setWinCalled(true);
+    if (gameStatus === 'won' && !winCalledRef.current) {
+      winCalledRef.current = true;
       setTaunt(randomTaunt('lost'));
       const timer = setTimeout(() => onWinRef.current(), 800);
       return () => clearTimeout(timer);
@@ -257,7 +257,7 @@ export default function Chess_Game({ onWin }: ChessProps) {
     if (gameStatus === 'draw') {
       setTaunt('Stalemate... I\'ll take it.');
     }
-  }, [gameStatus, winCalled]);
+  }, [gameStatus]);
 
   // ─── Make a move (with animation) ──────────────────────────────────────
 
@@ -372,7 +372,7 @@ export default function Chess_Game({ onWin }: ChessProps) {
     setLastMove(null);
     setBotThinking(false);
     setAnimatingMove(null);
-    setWinCalled(false);
+    winCalledRef.current = false;
     setTaunt('Beat me at chess and you can leave a message.');
   }, []);
 


### PR DESCRIPTION
Mouse movement caused frequent re-renders in page.tsx, creating a new
onWin reference each time. This triggered the win useEffect cleanup in
Chess.tsx, cancelling the 800ms onWin timer before it could fire (since
winCalled was already true, no new timer was started).

Fix: store onWin in a ref so the effect only depends on gameStatus and
winCalled, making it immune to parent re-renders.

https://claude.ai/code/session_014hHnzfZi2tUux7b45m8ZGT