### PR TITLE
Fix iPad portrait message cutoff by raising mobile breakpoint to 1024px

### DIFF
--- a/app/message-board/page.tsx
+++ b/app/message-board/page.tsx
@@ -280,7 +280,7 @@ export default function MessageBoardPage() {
   const wordCount = text.trim() ? text.trim().split(/\s+/).length : 0;
 
   useEffect(() => {
-    const mq = window.matchMedia('(max-width: 768px)');
+    const mq = window.matchMedia('(max-width: 1024px)');
     setIsMobile(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
     mq.addEventListener('change', handler);


### PR DESCRIPTION
The 3x3 absolute-positioned desktop grid requires ~940px usable width.
iPads in portrait mode (820px–1024px) exceeded the old 768px breakpoint
so they got the desktop layout, clipping the left/right column cards.
Raising the breakpoint to 1024px ensures all iPad portrait widths use
the stacked mobile layout which fits correctly and is touch-friendly.

https://claude.ai/code/session_01FrHwNR8PESyf2ZRazKxeqQ